### PR TITLE
Improve mobile gesture playback handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
 
     let ultimaLectura = { x: 0, y: 0, z: 0 };
     let tiempoUltimaAgitacion = 0;
+    let videoActual = null;
 
     // --- Utilidades video
     function ocultarTodos() {
@@ -83,8 +84,13 @@
         v.currentTime = 0;
         v.style.display = "none";
       });
+      videoActual = null;
     }
     async function reproducir(v) {
+      if (videoActual === v && !v.paused) {
+        return; // ya se está reproduciendo ese video
+      }
+
       ocultarTodos();
       v.style.display = "block";
 
@@ -95,6 +101,7 @@
 
       try {
         await v.play();
+        videoActual = v;
       } catch (err) {
         console.warn("No se pudo reproducir el video:", err);
         // Si falla, mostramos controles para permitir play manual
@@ -103,6 +110,9 @@
     }
     [videoDerecha, videoIzquierda, videoVomita].forEach(v => {
       v.addEventListener('ended', () => {
+        if (videoActual === v) {
+          videoActual = null;
+        }
         v.style.display = "none";
       });
       v.addEventListener('error', (e) => {


### PR DESCRIPTION
## Summary
- track the currently playing clip to prevent duplicate restarts when the same gesture event fires repeatedly
- reset the active video reference once playback completes so future gestures can trigger the correct clip

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddbf6cb14832f8163ca32623be1b0)